### PR TITLE
chore(deps): force uuid 11.1.1 to clear last security advisory (#48)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "resolutions": {
     "serialize-javascript": "^7.0.5",
-    "@docusaurus/plugin-content-docs": "3.10.1"
+    "@docusaurus/plugin-content-docs": "3.10.1",
+    "uuid": "^11.1.1"
   },
   "browserslist": {
     "production": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -9219,10 +9219,10 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@^11.1.1, uuid@^8.3.2:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 value-equal@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Closes the last remaining open Dependabot alert (#48, uuid).

## Change
Adds a yarn resolution `uuid: ^11.1.1` (resolves to 11.1.1). uuid was only pulled transitively via `webpack-dev-server → sockjs`, which pins `uuid@^8`.

## Why this is safe
- sockjs uses `require('uuid').v4` and calls it **without a `buf` argument** (`lib/transport.js:9,37`) — and the advisory only affects `v3/v5/v6` when `buf` is provided. The bump is purely belt-and-suspenders, but it clears the alert cleanly.
- The `.v4` named export is available and CommonJS-`require`-able in uuid 11, so it is API-compatible with sockjs.
- uuid is the **only** consumer of the package in the dependency tree, so nothing else is affected.

## Verification
- `require('uuid').v4()` returns a valid v4 UUID under 11.1.1
- `yarn build` succeeds (static output + search index + llms.txt)
- `yarn start` boots the webpack-dev-server / sockjs stack with no errors

After this merges, the Dependabot security tab should reach **0 open alerts**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)