### PR TITLE
ci: restrict GITHUB_TOKEN permissions in workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,9 @@ on:
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -7,6 +7,9 @@ on:
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 
+permissions:
+  contents: read
+
 jobs:
   test-deploy:
     name: Test deployment


### PR DESCRIPTION
Resolves the two open CodeQL code-scanning alerts (`actions/missing-workflow-permissions`, medium severity).

## Change
Add an explicit `permissions: contents: read` block to both workflows so the `GITHUB_TOKEN` follows least-privilege instead of getting the default broad write scope.

- `deploy.yml` — deploys via rsync to an external host, writes nothing back to the repo → read is sufficient.
- `test-deploy.yml` — only builds the site → read is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)