### PR TITLE
docs: clarify groups as labels on both nodes and resources

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -13,6 +13,10 @@ The **control plane** is the authority that holds and distributes a network's de
 
 The web user interface of the [controller](#controller--control-plane). Administrators use the dashboard to create networks, add and configure devices, manage groups, policies, and resources, and to invite users. The dashboard assigns each device its overlay IP address and hostname and writes the resulting configuration to the controller. See [Network Management](architecture/network-management.mdx).
 
+## Group
+
+A label attached to nodes and/or resources to express access intent. Used as the source or destination of a [policy](manage/policies.md), a group expands to the union of all nodes and all resources tagged with it. Group membership alone never grants access — a policy must explicitly allow the communication. A group with no member nodes can still be meaningful, because it may tag resources. See [Groups](manage/groups.md).
+
 ## Netsody agent / Data plane
 
 The **data plane** carries the actual traffic between devices. Devices connect directly over end-to-end encrypted connections whenever possible, assisted by [super peers](#super-peer) when no direct path is available. The **Netsody agent** is the component that implements this: it runs on each device, pulls the part of the network configuration relevant to that device from the [controller](#controller--control-plane), reconciles the local system with that desired state, and reports status back. It performs the end-to-end encryption and enforces access policies locally (Zero Trust), establishing direct or super-peer-relayed connections to its permitted peers. See [Netsody Agent](architecture/agent.mdx) and [Connectivity and Data Plane](architecture/connectivity.mdx).

--- a/docs/manage/groups.md
+++ b/docs/manage/groups.md
@@ -7,6 +7,8 @@ description: Use groups to organize devices and access rules.
 
 Groups are used to express access intent. A policy can allow one group to communicate with another group, and resources can be limited to selected groups.
 
+A group is a label that can be attached to both nodes and resources. When a group is used as the source or destination of a policy, it expands to the union of every node and every resource tagged with it. A resource can therefore be reached in two equivalent ways: by a policy that targets the resource directly, or by tagging the resource with a group and writing a policy that targets that group. Because of this, a group with no member nodes is not necessarily empty — it may still tag resources and grant access through them.
+
 <figure>
   <img src="/img/groups-list.jpeg" alt="Netsody controller Groups page showing group usage across nodes, policies, and resources" />
   <figcaption>The Groups view shows where each group is used: how many nodes belong to it, how many policies reference it, and how many resources use it.</figcaption>

--- a/docs/manage/policies.md
+++ b/docs/manage/policies.md
@@ -32,6 +32,8 @@ This lets you write policies at the level that matches the intended access: a gr
 
 Existing Netsody policies are evaluated bidirectionally for node-to-node access: if one node group is allowed to contact another node group, the reverse direction is allowed as well.
 
+A group used as a destination resolves to the union of the nodes and the resources tagged with it, so a resource can be reached either by targeting it directly or by targeting any group it belongs to.
+
 Resource access requires an explicit policy. The special `ALL` group applies to nodes, but it does not implicitly grant access to resources.
 
 ## Rules and conditions

--- a/docs/manage/resources.md
+++ b/docs/manage/resources.md
@@ -39,7 +39,7 @@ Each resource defines:
 
 - The destination that should be reachable.
 - The gateway node that forwards traffic.
-- The destination groups used by policies.
+- The groups attached to the resource. These both distribute the route to nodes in those groups and make the resource addressable as a policy destination under each group name.
 
 Resources require explicit policies. A node does not gain access only because it shares a group with a resource.
 


### PR DESCRIPTION
## Why

A common misreading — by both humans and LLM agents — is that a group with **0 member nodes** resolves to an empty set and is therefore an ineffective policy target. That inference is wrong: a group is a label that can be attached to **both nodes and resources**, and as a policy source/destination it expands to the **union** of all nodes and all resources tagged with it. The docs never stated this, so the dual role of groups (and the two equivalent ways to grant access to a resource) was invisible.

## What

A few targeted sentences on existing pages — no new pages.

- **groups.md** — new paragraph: groups are labels on both nodes and resources; a group expands to the union of both; two equivalent ways to reach a resource; "0 member nodes ≠ empty".
- **policies.md** — one sentence in *Directionality*: a destination group resolves to the union of tagged nodes and resources.
- **resources.md** — reworded the groups bullet to name its dual purpose (distributes the route **and** makes the resource addressable as a policy destination).
- **glossary.md** — new `## Group` entry capturing the union semantics and the non-empty caveat.

## Note

These edits reach humans and any agent that **reads** the doc pages (the controller MCP serves them live as resources). They do **not** change the MCP's inline tool-description strings, which still frame resource access as `resource::<dest>`-only. A follow-up to patch those tool descriptions in `netsody-controller-mcp` may be worthwhile if the docs alone don't close the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)