### PR TITLE
feat(self-hosting): optional node geolocation via geoip compose profile

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -275,6 +275,91 @@ netsody login \
 
 Repeat `--super-peer` to configure more than one Super Peer. The command stores the controller, OIDC, and Super Peer settings in the local agent config before starting the browser login flow. The controller, Super Peer list, and OIDC settings can be changed independently; `--auth-url` and `--auth-client-id` must always be supplied together.
 
+## Node geolocation (optional)
+
+The controller can show a country flag and city for each node, derived from the public IP address the controller already observes when a node reports metrics. This is optional and disabled by default.
+
+Netsody resolves the location locally with a MaxMind GeoLite2-City database, so node IP addresses are never sent to a third party. The controller only reads the database file; it never downloads or redistributes it. Each operator obtains the data directly from MaxMind under their own license.
+
+### Get a MaxMind license key
+
+Create a free MaxMind account and generate a license key:
+
+- Sign up at `https://www.maxmind.com/en/geolite2/signup`.
+- In your MaxMind account, create a license key under `Manage License Keys`.
+
+Note your MaxMind account ID and license key. Using GeoLite2 requires accepting the MaxMind GeoLite2 End User License Agreement.
+
+### Add the geoipupdate sidecar
+
+The `geoipupdate` sidecar keeps `GeoLite2-City.mmdb` current in a shared volume that the controller reads. MaxMind publishes database updates twice per week.
+
+Add your MaxMind credentials to `.env`:
+
+```dotenv
+GEOIPUPDATE_ACCOUNT_ID=<maxmind-account-id>
+GEOIPUPDATE_LICENSE_KEY=<maxmind-license-key>
+```
+
+Add the sidecar service to `docker-compose.yml`:
+
+```yaml
+  netsody-controller-geoip:
+    image: ghcr.io/maxmind/geoipupdate:v7
+    restart: unless-stopped
+    environment:
+      GEOIPUPDATE_ACCOUNT_ID: ${GEOIPUPDATE_ACCOUNT_ID}
+      GEOIPUPDATE_LICENSE_KEY: ${GEOIPUPDATE_LICENSE_KEY}
+      GEOIPUPDATE_EDITION_IDS: GeoLite2-City
+      GEOIPUPDATE_FREQUENCY: "72"
+    volumes:
+      - netsody_controller_geoip:/usr/share/GeoIP
+    networks:
+      - netsody-controller
+```
+
+Add these keys to the existing `netsody-controller` service so it can read the database file:
+
+```yaml
+  netsody-controller:
+    environment:
+      GEOIP_DB_PATH: /geoip/GeoLite2-City.mmdb
+    volumes:
+      - netsody_controller_geoip:/geoip:ro
+```
+
+Add the named volume next to the other volumes at the bottom of `docker-compose.yml`:
+
+```yaml
+volumes:
+  netsody_controller_geoip:
+```
+
+`GEOIPUPDATE_FREQUENCY` is in hours; `72` refreshes every three days. The `:ro` mount keeps the controller's access to the database read-only.
+
+### Apply and verify
+
+Recreate the stack so the new service and volume are created:
+
+```bash
+docker compose --profile pocket-id up -d
+```
+
+The controller loads the database once at startup. On the very first run the controller can start before `geoipupdate` has finished the initial download; if so, restart the controller once the database file exists:
+
+```bash
+docker compose logs netsody-controller-geoip
+docker compose restart netsody-controller
+```
+
+The controller logs `GeoIP database loaded from /geoip/GeoLite2-City.mmdb` when geolocation is active. If the database is missing or `GEOIP_DB_PATH` is unset, geolocation is simply disabled and all other node metrics keep working.
+
+When you show the location in a user-facing surface, include the MaxMind attribution, for example: `This product includes GeoLite2 data created by MaxMind, available from https://www.maxmind.com`.
+
+### Privacy
+
+Node location is a separate item in the metrics privacy model. Users control it with the `location` visibility toggle, independently of their exact IP address (`ip_addresses`), so a user can share a coarse location without exposing the observed public IP.
+
 ## Operations
 
 Restart the stack:

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -283,7 +283,7 @@ Repeat `--super-peer` to configure more than one Super Peer. The command stores 
 
 ## Node geolocation (optional)
 
-The controller can show a country flag and city for each node, derived from the public IP address the controller already observes when a node reports its status. This is optional and disabled by default.
+The controller can show the country and city for each node, derived from the public IP address the controller already observes when a node reports its status. This is optional and disabled by default.
 
 Netsody resolves the location locally with a MaxMind GeoLite2-City database, so node IP addresses are never sent to a third party.
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -141,6 +141,12 @@ S3_FORCE_PATH_STYLE=true
 NETSODY_CONTROLLER_MINIO_PORT=9000
 NETSODY_CONTROLLER_MINIO_CONSOLE_PORT=40091
 
+# Optional node geolocation. To enable, set the MaxMind credentials and
+# GEOIP_DB_PATH=/geoip/GeoLite2-City.mmdb, then start with `--profile geoip`.
+GEOIP_DB_PATH=
+GEOIPUPDATE_ACCOUNT_ID=
+GEOIPUPDATE_LICENSE_KEY=
+
 # Super Peer
 NETSODY_SP_UDP_PORT=443
 NETSODY_SP_ALT_SVC_PORT=443
@@ -290,59 +296,22 @@ Create a free MaxMind account and generate a license key:
 
 Note your MaxMind account ID and license key.
 
-### Add the geoipupdate sidecar
+### Enable geolocation
 
-The `geoipupdate` sidecar keeps `GeoLite2-City.mmdb` current in a shared volume that the controller reads. MaxMind publishes database updates twice per week.
+The stack includes an optional `geoipupdate` sidecar, behind the `geoip` Compose profile, that keeps `GeoLite2-City.mmdb` current in a shared volume the controller reads. MaxMind publishes database updates twice per week.
 
-Add your MaxMind credentials to `.env`:
+Set your MaxMind credentials and the database path in `.env`:
 
 ```dotenv
+GEOIP_DB_PATH=/geoip/GeoLite2-City.mmdb
 GEOIPUPDATE_ACCOUNT_ID=<maxmind-account-id>
 GEOIPUPDATE_LICENSE_KEY=<maxmind-license-key>
 ```
 
-Add the sidecar service to `docker-compose.yml`:
-
-```yaml
-  netsody-controller-geoip:
-    image: ghcr.io/maxmind/geoipupdate:v7
-    restart: unless-stopped
-    environment:
-      GEOIPUPDATE_ACCOUNT_ID: ${GEOIPUPDATE_ACCOUNT_ID}
-      GEOIPUPDATE_LICENSE_KEY: ${GEOIPUPDATE_LICENSE_KEY}
-      GEOIPUPDATE_EDITION_IDS: GeoLite2-City
-      GEOIPUPDATE_FREQUENCY: "72"
-    volumes:
-      - netsody_controller_geoip:/usr/share/GeoIP
-    networks:
-      - netsody-controller
-```
-
-Add these keys to the existing `netsody-controller` service so it can read the database file:
-
-```yaml
-  netsody-controller:
-    environment:
-      GEOIP_DB_PATH: /geoip/GeoLite2-City.mmdb
-    volumes:
-      - netsody_controller_geoip:/geoip:ro
-```
-
-Add the named volume next to the other volumes at the bottom of `docker-compose.yml`:
-
-```yaml
-volumes:
-  netsody_controller_geoip:
-```
-
-`GEOIPUPDATE_FREQUENCY` is in hours; `72` refreshes every three days. The `:ro` mount keeps the controller's access to the database read-only.
-
-### Apply and verify
-
-Recreate the stack so the new service and volume are created:
+Start the stack with the `geoip` profile added to the profiles you already use:
 
 ```bash
-docker compose --profile pocket-id up -d
+docker compose --profile pocket-id --profile geoip up -d
 ```
 
 The controller loads the database once at startup. On the very first run the controller can start before `geoipupdate` has finished the initial download; if so, restart the controller once the database file exists:
@@ -352,7 +321,7 @@ docker compose logs netsody-controller-geoip
 docker compose restart netsody-controller
 ```
 
-The controller logs `GeoIP database loaded from /geoip/GeoLite2-City.mmdb` when geolocation is active. If the database is missing or `GEOIP_DB_PATH` is unset, geolocation is simply disabled and the rest of the node status keeps working.
+The controller logs `GeoIP database loaded from /geoip/GeoLite2-City.mmdb` when geolocation is active. If `GEOIP_DB_PATH` is empty or the database is missing, geolocation is simply disabled and the rest of the node status keeps working.
 
 When you show the location in a user-facing surface, include the MaxMind attribution, for example: `This product includes GeoLite2 data created by MaxMind, available from https://www.maxmind.com`.
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -288,7 +288,7 @@ Create a free MaxMind account and generate a license key:
 - Sign up at `https://www.maxmind.com/en/geolite2/signup`.
 - In your MaxMind account, create a license key under `Manage License Keys`.
 
-Note your MaxMind account ID and license key. Using GeoLite2 requires accepting the MaxMind GeoLite2 End User License Agreement.
+Note your MaxMind account ID and license key.
 
 ### Add the geoipupdate sidecar
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -277,7 +277,7 @@ Repeat `--super-peer` to configure more than one Super Peer. The command stores 
 
 ## Node geolocation (optional)
 
-The controller can show a country flag and city for each node, derived from the public IP address the controller already observes when a node reports metrics. This is optional and disabled by default.
+The controller can show a country flag and city for each node, derived from the public IP address the controller already observes when a node reports its status. This is optional and disabled by default.
 
 Netsody resolves the location locally with a MaxMind GeoLite2-City database, so node IP addresses are never sent to a third party. The controller only reads the database file; it never downloads or redistributes it. Each operator obtains the data directly from MaxMind under their own license.
 
@@ -352,13 +352,13 @@ docker compose logs netsody-controller-geoip
 docker compose restart netsody-controller
 ```
 
-The controller logs `GeoIP database loaded from /geoip/GeoLite2-City.mmdb` when geolocation is active. If the database is missing or `GEOIP_DB_PATH` is unset, geolocation is simply disabled and all other node metrics keep working.
+The controller logs `GeoIP database loaded from /geoip/GeoLite2-City.mmdb` when geolocation is active. If the database is missing or `GEOIP_DB_PATH` is unset, geolocation is simply disabled and the rest of the node status keeps working.
 
 When you show the location in a user-facing surface, include the MaxMind attribution, for example: `This product includes GeoLite2 data created by MaxMind, available from https://www.maxmind.com`.
 
 ### Privacy
 
-Node location is a separate item in the metrics privacy model. Users control it with the `location` visibility toggle, independently of their exact IP address (`ip_addresses`), so a user can share a coarse location without exposing the observed public IP.
+Node location is a separate item in the status privacy model. Users control it with the `location` visibility toggle, independently of their exact IP address (`ip_addresses`), so a user can share a coarse location without exposing the observed public IP.
 
 ## Operations
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -279,7 +279,7 @@ Repeat `--super-peer` to configure more than one Super Peer. The command stores 
 
 The controller can show a country flag and city for each node, derived from the public IP address the controller already observes when a node reports its status. This is optional and disabled by default.
 
-Netsody resolves the location locally with a MaxMind GeoLite2-City database, so node IP addresses are never sent to a third party. The controller only reads the database file; it never downloads or redistributes it. Each operator obtains the data directly from MaxMind under their own license.
+Netsody resolves the location locally with a MaxMind GeoLite2-City database, so node IP addresses are never sent to a third party.
 
 ### Get a MaxMind license key
 

--- a/static/downloads/docker-compose.yml
+++ b/static/downloads/docker-compose.yml
@@ -118,10 +118,12 @@ services:
       S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID:-minio}
       S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY:-minio123}
       S3_FORCE_PATH_STYLE: ${S3_FORCE_PATH_STYLE:-true}
+      GEOIP_DB_PATH: ${GEOIP_DB_PATH:-}
     expose:
       - "8080"
     volumes:
       - netsody_controller_service_data:/app/data
+      - netsody_controller_geoip:/geoip:ro
     depends_on:
       - netsody-controller-db
       - netsody-controller-minio
@@ -142,6 +144,21 @@ services:
       - "traefik.http.middlewares.netsody-controller-redirect.redirectscheme.scheme=https"
       - "traefik.http.middlewares.netsody-controller-redirect.redirectscheme.permanent=true"
       - "traefik.http.services.netsody-controller.loadbalancer.server.port=8080"
+
+  netsody-controller-geoip:
+    image: ghcr.io/maxmind/geoipupdate:v7
+    restart: unless-stopped
+    profiles:
+      - geoip
+    environment:
+      GEOIPUPDATE_ACCOUNT_ID: ${GEOIPUPDATE_ACCOUNT_ID:-}
+      GEOIPUPDATE_LICENSE_KEY: ${GEOIPUPDATE_LICENSE_KEY:-}
+      GEOIPUPDATE_EDITION_IDS: GeoLite2-City
+      GEOIPUPDATE_FREQUENCY: "72"
+    volumes:
+      - netsody_controller_geoip:/usr/share/GeoIP
+    networks:
+      - netsody-controller
 
   netsody-dashboard:
     image: netsody/dashboard:latest
@@ -259,5 +276,6 @@ volumes:
   netsody_sp_certbot_log:
   netsody_controller_db_data:
   netsody_controller_service_data:
+  netsody_controller_geoip:
   netsody_controller_minio_data:
   pocket_id_data:


### PR DESCRIPTION
Ships the optional **node geolocation** feature (country and city per node; controller side in netsody/controller#94) in the self-hosting docs and downloads.

## What this adds
- **`static/downloads/docker-compose.yml`**: a `netsody-controller-geoip` (geoipupdate) service behind an optional **`geoip` profile**, a shared GeoIP volume mounted read-only into the controller, and the controller's optional **`GEOIP_DB_PATH`**.
- **`docs/self-hosting.md`**: `GEOIP_DB_PATH` / `GEOIPUPDATE_*` added to the inline `.env` block, and a "Node geolocation (optional)" section — enable with `.env` values + `docker compose --profile geoip up -d`.

## Behaviour
Disabled by default. Enabling needs a free MaxMind GeoLite2 key; the controller only reads the local database, so node IPs never leave the controller. Location is gated by the separate `location` status-visibility toggle.

Note: the self-hosting page still provides `.env` as an inline copy-paste block (only `docker-compose.yml` is a download). Adding a downloadable `.env.example` could follow if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)